### PR TITLE
feat: P2 — architecture-aware prompts with ACP and drift observation …

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -104,6 +104,9 @@ tekhton.sh (entry)
 | `TESTER_REPORT.md` | PROJECT_DIR | Tester output (per-run) |
 | `JR_CODER_SUMMARY.md` | PROJECT_DIR | Jr coder output (per-run) |
 | `HUMAN_NOTES.md` | PROJECT_DIR | Human-written notes for next run |
+| `ARCHITECTURE_LOG.md` | PROJECT_DIR | Architecture Decision Log (accepted ACPs across runs) |
+| `DRIFT_LOG.md` | PROJECT_DIR | Drift observations accumulated across runs |
+| `HUMAN_ACTION_REQUIRED.md` | PROJECT_DIR | Items needing human attention (design doc updates) |
 
 ## Extension Points
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,12 @@ Available variables in prompt templates — set by the pipeline before rendering
 | `INLINE_CONTRACT_PATTERN` | pipeline.conf (optional) |
 | `BUILD_ERRORS_CONTENT` | Contents of BUILD_ERRORS.md |
 | `ANALYZE_ISSUES` | Output of ANALYZE_CMD |
+| `DESIGN_FILE` | pipeline.conf (optional — design doc path) |
+| `ARCHITECTURE_LOG_FILE` | pipeline.conf (default: ARCHITECTURE_LOG.md) |
+| `DRIFT_LOG_FILE` | pipeline.conf (default: DRIFT_LOG.md) |
+| `HUMAN_ACTION_FILE` | pipeline.conf (default: HUMAN_ACTION_REQUIRED.md) |
+| `DRIFT_OBSERVATION_THRESHOLD` | pipeline.conf (default: 8) |
+| `DRIFT_RUNS_SINCE_AUDIT_THRESHOLD` | pipeline.conf (default: 5) |
 
 ## Testing
 

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -64,6 +64,13 @@ load_config() {
     : "${SEED_CONTRACTS_ENABLED:=false}"
     : "${DESIGN_FILE:=}"
 
+    # --- Drift detection defaults ---
+    : "${ARCHITECTURE_LOG_FILE:=ARCHITECTURE_LOG.md}"
+    : "${DRIFT_LOG_FILE:=DRIFT_LOG.md}"
+    : "${HUMAN_ACTION_FILE:=HUMAN_ACTION_REQUIRED.md}"
+    : "${DRIFT_OBSERVATION_THRESHOLD:=8}"
+    : "${DRIFT_RUNS_SINCE_AUDIT_THRESHOLD:=5}"
+
     # Milestone overrides — defaults to 2x normal if not specified
     : "${MILESTONE_MAX_REVIEW_CYCLES:=$(( MAX_REVIEW_CYCLES * 2 ))}"
     : "${MILESTONE_CODER_MAX_TURNS:=$(( CODER_MAX_TURNS * 2 ))}"

--- a/prompts/coder.prompt.md
+++ b/prompts/coder.prompt.md
@@ -58,6 +58,39 @@ Use system names from {{ARCHITECTURE_FILE}}.
 This enables `grep -r 'System:'` to find all files in a system instantly.
 {{ENDIF:INLINE_CONTRACT_PATTERN}}
 
+## Architecture Change Proposals
+
+If your implementation requires a structural change not described in the architecture
+documentation — a new dependency between systems, a different layer boundary, a changed
+interface contract — you MUST declare it in CODER_SUMMARY.md under a new section:
+
+### `## Architecture Change Proposals`
+For each proposed change:
+- **Current constraint**: What the architecture doc says or implies
+- **What triggered this**: Why the current constraint doesn't work
+- **Proposed change**: What you changed and why it's the right approach
+- **Backward compatible**: Yes/No — does existing code still work without this?
+- **ARCHITECTURE.md update needed**: Yes/No — specify which section
+
+Do NOT stop working to wait for approval. Implement the best solution, declare
+the change, and make it defensible. The reviewer will evaluate your proposal.
+
+If no architecture changes were needed, omit this section entirely.
+{{IF:DESIGN_FILE}}
+
+## Design Observations
+
+If you encounter anything in the design document ({{DESIGN_FILE}}) that contradicts
+what was decided in a prior Architecture Change Proposal, or that conflicts with
+current implementation reality, note it in CODER_SUMMARY.md:
+
+### `## Design Observations`
+- Brief description of the contradiction and which document sections are affected
+
+These are informational — the human decides whether to update the design doc.
+Do not block your work on design contradictions.
+{{ENDIF:DESIGN_FILE}}
+
 ## Required Output
 When finished, update CODER_SUMMARY.md with:
 - '## Status' set to either 'COMPLETE' or 'IN PROGRESS'

--- a/prompts/coder_rework.prompt.md
+++ b/prompts/coder_rework.prompt.md
@@ -4,7 +4,9 @@ You are the senior implementation agent for {{PROJECT_NAME}}. Your role definiti
 Original task: {{TASK}}
 
 A code review found blockers. Read `REVIEWER_REPORT.md` and fix **only the items under 'Complex Blockers (send to senior coder)'**.
+- If there are REJECTED or MODIFIED ACPs under `## ACP Verdicts`, those are also your responsibility
 - Do NOT re-read {{PROJECT_RULES_FILE}} or other project docs unless a specific blocker requires it
 - Do NOT touch Simple Blockers — those go to jr coder
 - Do NOT refactor anything not mentioned in the blockers
 - Update `CODER_SUMMARY.md` to reflect what changed
+- If you reworked an ACP, update the `## Architecture Change Proposals` section in CODER_SUMMARY.md accordingly

--- a/prompts/reviewer.prompt.md
+++ b/prompts/reviewer.prompt.md
@@ -61,4 +61,47 @@ The pipeline parses these exact headings. 'None' must be the literal word None o
 when a section is empty — do not use 'No complex blockers found' or similar phrases.
 Do not use bold text, numbered lists, or alternative headings for the blocker sections.
 
+## Architecture Change Proposal Evaluation
+
+If CODER_SUMMARY.md contains an `## Architecture Change Proposals` section,
+you MUST evaluate each proposal:
+
+For each ACP, write one of:
+- **ACCEPT** — The change is legitimate and well-implemented
+- **REJECT** — Unnecessary; describe how to solve within existing architecture.
+  This becomes a Complex Blocker.
+- **MODIFY** — Change is needed but approach should differ. Complex Blocker with guidance.
+
+Write your evaluations in REVIEWER_REPORT.md as an additional section:
+
+### `## ACP Verdicts`
+- ACP: [name] — ACCEPT / REJECT / MODIFY — [one-line rationale]
+
+ACPs that are REJECT or MODIFY count as Complex Blockers (code must be reworked).
+ACPs that are ACCEPT do not block — note them so the architecture doc can be updated.
+
+If there is no `## Architecture Change Proposals` section in CODER_SUMMARY.md,
+omit the `## ACP Verdicts` section entirely.
+
+## Drift Observations
+
+While reviewing the changed files, note any cross-cutting concerns that aren't
+blockers for THIS commit but suggest systemic issues. Examples:
+- Same concept called different names in different files
+- Function that appears to duplicate logic elsewhere
+- Import that crosses a layer boundary defined in the architecture doc
+- Config value that exists in JSON but isn't used by any code path you reviewed
+- Dead code (unreachable methods, unused parameters)
+- Test that tests outdated behavior
+
+Write observations in REVIEWER_REPORT.md under:
+
+### `## Drift Observations`
+- [file:line or general area] — description of the observation
+
+Or 'None' if nothing observed.
+
+These are NOT blockers. They accumulate in a log across runs and trigger a
+dedicated audit when enough have built up.
+
 Write `REVIEWER_REPORT.md`.

--- a/stages/review.sh
+++ b/stages/review.sh
@@ -59,6 +59,18 @@ run_stage_review() {
         fi
         log "Reviewer verdict: ${BOLD}${VERDICT}${NC}"
 
+        # --- Parse ACP verdicts (if present) ---------------------------------
+        # Extract accepted ACPs for downstream processing (P3 drift log will consume)
+        ACCEPTED_ACPS=""
+        if grep -q "^## ACP Verdicts" REVIEWER_REPORT.md 2>/dev/null; then
+            ACCEPTED_ACPS=$(awk '/^## ACP Verdicts/{found=1; next} found && /^##/{exit} found && /ACCEPT/{print}' \
+                REVIEWER_REPORT.md 2>/dev/null || true)
+            if [ -n "$ACCEPTED_ACPS" ]; then
+                log "Accepted ACPs found:"
+                echo "$ACCEPTED_ACPS" | sed 's/^/  /'
+            fi
+        fi
+
         if [ "$VERDICT" = "CHANGES_REQUIRED" ]; then
             # --- Count blockers ----------------------------------------------
             TMPDIR_BLOCKS=$(mktemp -d)

--- a/templates/coder.md
+++ b/templates/coder.md
@@ -33,5 +33,25 @@ When finished, write or update `CODER_SUMMARY.md` with:
 - `## What Was Implemented`: bullet list of changes
 - `## Files Created or Modified`: paths and brief descriptions
 - `## Remaining Work`: anything unfinished (only if IN PROGRESS)
+- `## Architecture Change Proposals`: (if applicable, see below)
 
 Do NOT set COMPLETE if any planned work is unfinished.
+
+## Architecture Change Proposals
+
+If your implementation requires a structural change not described in the architecture
+documentation — a new dependency between systems, a different layer boundary, a changed
+interface contract — declare it in CODER_SUMMARY.md under a new section:
+
+### `## Architecture Change Proposals`
+For each proposed change:
+- **Current constraint**: What the architecture doc says or implies
+- **What triggered this**: Why the current constraint doesn’t work
+- **Proposed change**: What you changed and why it’s the right approach
+- **Backward compatible**: Yes/No — does existing code still work without this?
+- **ARCHITECTURE.md update needed**: Yes/No — specify which section
+
+Do NOT stop working to wait for approval. Implement the best solution, declare
+the change, and make it defensible. The reviewer will evaluate your proposal.
+
+If no architecture changes were needed, omit this section entirely.

--- a/templates/pipeline.conf.example
+++ b/templates/pipeline.conf.example
@@ -94,8 +94,24 @@ ARCHITECTURE_FILE="ARCHITECTURE.md"
 GLOSSARY_FILE=""
 PROJECT_RULES_FILE="CLAUDE.md"
 
-# --- Design document (optional — used by drift detection in future versions) -
+# --- Design document (optional — enables design cross-referencing) -----------
 DESIGN_FILE=""
+
+# --- Architecture drift configuration ----------------------------------------
+# Path to the architecture decision log (records accepted ACPs)
+ARCHITECTURE_LOG_FILE="ARCHITECTURE_LOG.md"
+
+# Path to the drift observation log (accumulated across runs)
+DRIFT_LOG_FILE="DRIFT_LOG.md"
+
+# Path to the human action required file (design doc changes needed)
+HUMAN_ACTION_FILE="HUMAN_ACTION_REQUIRED.md"
+
+# Trigger architect audit after this many unresolved drift observations
+DRIFT_OBSERVATION_THRESHOLD=8
+
+# Trigger architect audit after this many pipeline runs since last audit
+DRIFT_RUNS_SINCE_AUDIT_THRESHOLD=5
 
 # --- Human notes configuration ----------------------------------------------
 # Valid categories for --notes-filter (pipe-separated for case matching)

--- a/templates/reviewer.md
+++ b/templates/reviewer.md
@@ -50,3 +50,23 @@ APPROVED | APPROVED_WITH_NOTES | CHANGES_REQUIRED
 
 The pipeline parses these exact headings. Use the literal word `None` when a
 section has no items.
+
+## Architecture Change Proposal Evaluation
+
+If CODER_SUMMARY.md contains an `## Architecture Change Proposals` section,
+evaluate each proposal:
+
+- **ACCEPT** — Legitimate and well-implemented
+- **REJECT** — Unnecessary; explain how to solve within existing architecture (Complex Blocker)
+- **MODIFY** — Change needed but approach should differ (Complex Blocker with guidance)
+
+Write in REVIEWER_REPORT.md under `## ACP Verdicts`. Omit if no ACPs present.
+
+## Drift Observations
+
+While reviewing, note cross-cutting concerns that aren’t blockers but suggest
+systemic issues (naming inconsistencies, duplicated logic, layer boundary
+violations, dead code, tests testing outdated behavior).
+
+Write in REVIEWER_REPORT.md under `## Drift Observations` (or ‘None’ if nothing
+observed). These accumulate across runs for periodic audit.

--- a/tests/test_drift_config.sh
+++ b/tests/test_drift_config.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Test: Drift detection config keys load with sensible defaults
+set -euo pipefail
+
+TEKHTON_HOME="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# Create a minimal project with pipeline.conf (no drift keys set)
+PROJECT_DIR="$TMPDIR"
+mkdir -p "${PROJECT_DIR}/.claude/agents"
+mkdir -p "${PROJECT_DIR}/.claude/logs"
+
+cat > "${PROJECT_DIR}/.claude/pipeline.conf" << 'EOF'
+PROJECT_NAME="Drift Test Project"
+PROJECT_DESCRIPTION="test"
+REQUIRED_TOOLS="git"
+CLAUDE_CODER_MODEL="claude-opus-4-6"
+CLAUDE_JR_CODER_MODEL="claude-haiku-4-5"
+CLAUDE_STANDARD_MODEL="claude-sonnet-4-6"
+CLAUDE_TESTER_MODEL="claude-haiku-4-5"
+CODER_MAX_TURNS=10
+JR_CODER_MAX_TURNS=5
+REVIEWER_MAX_TURNS=5
+TESTER_MAX_TURNS=10
+MAX_REVIEW_CYCLES=2
+ANALYZE_CMD="echo ok"
+TEST_CMD="echo ok"
+PIPELINE_STATE_FILE=".claude/PIPELINE_STATE.md"
+LOG_DIR=".claude/logs"
+CODER_ROLE_FILE=".claude/agents/coder.md"
+REVIEWER_ROLE_FILE=".claude/agents/reviewer.md"
+TESTER_ROLE_FILE=".claude/agents/tester.md"
+JR_CODER_ROLE_FILE=".claude/agents/jr-coder.md"
+PROJECT_RULES_FILE="CLAUDE.md"
+EOF
+
+for role in coder reviewer tester jr-coder; do
+    echo "# ${role}" > "${PROJECT_DIR}/.claude/agents/${role}.md"
+done
+echo "# Rules" > "${PROJECT_DIR}/CLAUDE.md"
+
+# Source common + config
+source "${TEKHTON_HOME}/lib/common.sh"
+source "${TEKHTON_HOME}/lib/config.sh"
+
+load_config
+
+# --- Test 1: Defaults are set when not specified in pipeline.conf ---
+FAIL=0
+
+assert_eq() {
+    local name="$1" expected="$2" actual="$3"
+    if [ "$expected" != "$actual" ]; then
+        echo "FAIL: $name — expected '$expected', got '$actual'"
+        FAIL=1
+    fi
+}
+
+assert_eq "ARCHITECTURE_LOG_FILE default" "ARCHITECTURE_LOG.md" "$ARCHITECTURE_LOG_FILE"
+assert_eq "DRIFT_LOG_FILE default" "DRIFT_LOG.md" "$DRIFT_LOG_FILE"
+assert_eq "HUMAN_ACTION_FILE default" "HUMAN_ACTION_REQUIRED.md" "$HUMAN_ACTION_FILE"
+assert_eq "DRIFT_OBSERVATION_THRESHOLD default" "8" "$DRIFT_OBSERVATION_THRESHOLD"
+assert_eq "DRIFT_RUNS_SINCE_AUDIT_THRESHOLD default" "5" "$DRIFT_RUNS_SINCE_AUDIT_THRESHOLD"
+assert_eq "DESIGN_FILE default" "" "$DESIGN_FILE"
+
+# --- Test 2: Custom values override defaults ---
+cat >> "${PROJECT_DIR}/.claude/pipeline.conf" << 'EOF'
+ARCHITECTURE_LOG_FILE="ADL.md"
+DRIFT_LOG_FILE="MY_DRIFT.md"
+HUMAN_ACTION_FILE="ACTIONS.md"
+DRIFT_OBSERVATION_THRESHOLD=15
+DRIFT_RUNS_SINCE_AUDIT_THRESHOLD=10
+DESIGN_FILE="docs/design.md"
+EOF
+
+# Reload config with custom values
+load_config
+
+assert_eq "ARCHITECTURE_LOG_FILE custom" "ADL.md" "$ARCHITECTURE_LOG_FILE"
+assert_eq "DRIFT_LOG_FILE custom" "MY_DRIFT.md" "$DRIFT_LOG_FILE"
+assert_eq "HUMAN_ACTION_FILE custom" "ACTIONS.md" "$HUMAN_ACTION_FILE"
+assert_eq "DRIFT_OBSERVATION_THRESHOLD custom" "15" "$DRIFT_OBSERVATION_THRESHOLD"
+assert_eq "DRIFT_RUNS_SINCE_AUDIT_THRESHOLD custom" "10" "$DRIFT_RUNS_SINCE_AUDIT_THRESHOLD"
+assert_eq "DESIGN_FILE custom" "docs/design.md" "$DESIGN_FILE"
+
+if [ "$FAIL" -eq 0 ]; then
+    echo "All drift config tests passed."
+else
+    exit 1
+fi

--- a/tests/test_drift_prompts.sh
+++ b/tests/test_drift_prompts.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Test: ACP and drift observation sections render correctly in prompts
+set -euo pipefail
+
+TEKHTON_HOME="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+PROJECT_DIR="$TMPDIR"
+source "${TEKHTON_HOME}/lib/common.sh"
+source "${TEKHTON_HOME}/lib/prompts.sh"
+
+FAIL=0
+
+assert_contains() {
+    local name="$1" content="$2" pattern="$3"
+    if ! echo "$content" | grep -q "$pattern"; then
+        echo "FAIL: $name — expected pattern '$pattern' not found"
+        FAIL=1
+    fi
+}
+
+assert_not_contains() {
+    local name="$1" content="$2" pattern="$3"
+    if echo "$content" | grep -q "$pattern"; then
+        echo "FAIL: $name — unexpected pattern '$pattern' found"
+        FAIL=1
+    fi
+}
+
+# --- Test 1: Coder prompt includes ACP section (always present) ---
+# Set minimal required variables for rendering
+export PROJECT_NAME="Test" TASK="Implement feature" CODER_ROLE_FILE=".claude/agents/coder.md"
+export PROJECT_RULES_FILE="CLAUDE.md" ARCHITECTURE_FILE="ARCHITECTURE.md"
+export ANALYZE_CMD="echo ok" TEST_CMD="echo ok"
+export DESIGN_FILE=""  # Empty — Design Observations should be stripped
+
+CODER_OUTPUT=$(render_prompt "coder")
+assert_contains "Coder ACP section present" "$CODER_OUTPUT" "Architecture Change Proposals"
+assert_not_contains "Design Obs stripped when no DESIGN_FILE" "$CODER_OUTPUT" "Design Observations"
+
+# --- Test 2: Coder prompt includes Design Observations when DESIGN_FILE is set ---
+export DESIGN_FILE="docs/GDD.md"
+CODER_OUTPUT_WITH_DESIGN=$(render_prompt "coder")
+assert_contains "Design Obs present with DESIGN_FILE" "$CODER_OUTPUT_WITH_DESIGN" "Design Observations"
+assert_contains "Design file name in prompt" "$CODER_OUTPUT_WITH_DESIGN" "docs/GDD.md"
+
+# --- Test 3: Reviewer prompt includes ACP Evaluation and Drift sections ---
+export REVIEWER_ROLE_FILE=".claude/agents/reviewer.md"
+export REVIEW_CYCLE="1" MAX_REVIEW_CYCLES="2"
+export ARCHITECTURE_CONTENT="# Architecture"
+export PRIOR_BLOCKERS_BLOCK=""
+export INLINE_CONTRACT_PATTERN=""
+
+REVIEWER_OUTPUT=$(render_prompt "reviewer")
+assert_contains "Reviewer ACP eval section" "$REVIEWER_OUTPUT" "Architecture Change Proposal Evaluation"
+assert_contains "Reviewer drift obs section" "$REVIEWER_OUTPUT" "Drift Observations"
+assert_contains "Reviewer ACP verdicts heading" "$REVIEWER_OUTPUT" "ACP Verdicts"
+
+# --- Test 4: Coder rework prompt mentions ACP handling ---
+REWORK_OUTPUT=$(render_prompt "coder_rework")
+assert_contains "Rework mentions ACP" "$REWORK_OUTPUT" "REJECTED or MODIFIED ACPs"
+
+# --- Test 5: Existing prompts still render (backward compat) ---
+# These should not error out
+export JR_AFTER_SENIOR="" JR_CODER_ROLE_FILE=".claude/agents/jr-coder.md"
+render_prompt "jr_coder" > /dev/null
+render_prompt "coder_rework" > /dev/null
+
+if [ "$FAIL" -eq 0 ]; then
+    echo "All drift prompt tests passed."
+else
+    exit 1
+fi


### PR DESCRIPTION
…support

Coder prompt now instructs declaring Architecture Change Proposals (ACPs) when implementation requires deviations from documented architecture. Design Observations section (conditional on DESIGN_FILE) flags design doc contradictions.

Reviewer prompt now evaluates ACPs (ACCEPT/REJECT/MODIFY) and records drift observations — cross-cutting concerns that aren't blockers but accumulate for periodic audit.

Coder rework prompt updated to handle rejected/modified ACPs.

New config keys with defaults:
- ARCHITECTURE_LOG_FILE (ARCHITECTURE_LOG.md)
- DRIFT_LOG_FILE (DRIFT_LOG.md)
- HUMAN_ACTION_FILE (HUMAN_ACTION_REQUIRED.md)
- DRIFT_OBSERVATION_THRESHOLD (8)
- DRIFT_RUNS_SINCE_AUDIT_THRESHOLD (5)

review.sh now parses ACP Verdicts section and logs accepted ACPs. Agent role templates (--init) include ACP and drift instructions. Two new self-tests: drift config defaults + prompt rendering validation. All 7 tests pass.