### PR TITLE
feat: P5 — dependency constraint validation in build gate

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -55,7 +55,7 @@ Each stage is a single function sourced by `tekhton.sh`:
 - **`lib/common.sh`** — Colors, `log()`, `warn()`, `error()`, `success()`, `header()`, `require_cmd()`
 - **`lib/config.sh`** — `load_config()` reads `PROJECT_DIR/.claude/pipeline.conf`, validates required fields, applies milestone overrides via `apply_milestone_overrides()`
 - **`lib/agent.sh`** — `run_agent(name, model, turns, prompt, logfile)` wraps claude CLI invocation with JSON output parsing, turn counting, timing. `print_run_summary()` formats cumulative metrics.
-- **`lib/gates.sh`** — `run_build_gate(label)` runs `BUILD_CHECK_CMD`, captures errors to `BUILD_ERRORS.md`. `run_completion_gate()` runs `ANALYZE_CMD`, invokes cleanup agent on issues.
+- **`lib/gates.sh`** — `run_build_gate(label)` runs `ANALYZE_CMD`, `BUILD_CHECK_CMD`, and optionally a dependency constraint `validation_command` from the configured `architecture_constraints.yaml`. Captures all errors to `BUILD_ERRORS.md`. `run_completion_gate()` checks coder self-reported status from `CODER_SUMMARY.md`.
 - **`lib/hooks.sh`** — `archive_reports(dir, timestamp)`, `generate_commit_message(task)`, `run_final_checks(logfile)`.
 - **`lib/drift.sh`** — Drift log, Architecture Decision Log, and Human Action management. `append_drift_observations()` reads reviewer report and accumulates to `DRIFT_LOG.md`. `append_architecture_decision()` records accepted ACPs to `ARCHITECTURE_LOG.md` with sequential ADL-NNN IDs. `append_human_action(source, desc)` adds items to `HUMAN_ACTION_REQUIRED.md`. `process_drift_artifacts()` is the main post-pipeline integration point. `should_trigger_audit()` checks thresholds. Counter management via `increment_runs_since_audit()` / `reset_runs_since_audit()`.
 - **`lib/notes.sh`** — `count_human_notes()`, `extract_human_notes()`, `archive_human_notes()`. Respects `NOTES_FILTER` global.
@@ -141,6 +141,18 @@ tekhton.sh (entry)
 | `ARCHITECTURE_LOG.md` | PROJECT_DIR | Architecture Decision Log (accepted ACPs across runs) |
 | `DRIFT_LOG.md` | PROJECT_DIR | Drift observations accumulated across runs |
 | `HUMAN_ACTION_REQUIRED.md` | PROJECT_DIR | Items needing human attention (design doc updates) |
+| `architecture_constraints.yaml` | PROJECT_DIR | Optional dependency constraint manifest (layer rules + validation command) |
+
+## Dependency Constraint System (P5)
+
+Optional, language-agnostic enforcement of layer boundaries. When configured:
+
+1. **Constraint manifest** (`architecture_constraints.yaml`) defines layer rules and a `validation_command`
+2. **Build gate** runs the `validation_command` after analyze + compile checks. Nonzero exit = build failure.
+3. **Architect agent** reads the manifest during audits to verify drift observations against declared rules
+4. **Sample scripts** in `examples/` provide starting points for Dart, Python, and TypeScript projects
+
+The system is fully opt-in: when `DEPENDENCY_CONSTRAINTS_FILE` is empty (default), build gate skips validation and architect operates without layer context.
 
 ## Extension Points
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,11 @@ tekhton/
 │   ├── jr-coder.md
 │   └── architect.md
 ├── tests/                  # Self-tests
-└── examples/               # Example project configs
+└── examples/               # Sample dependency constraint validation scripts
+    ├── architecture_constraints.yaml  # Sample constraint manifest
+    ├── check_imports_dart.sh          # Dart/Flutter import validator
+    ├── check_imports_python.sh        # Python import validator
+    └── check_imports_typescript.sh    # TypeScript/JS import validator
 ```
 
 ## How It Works

--- a/examples/architecture_constraints.yaml
+++ b/examples/architecture_constraints.yaml
@@ -1,0 +1,86 @@
+# architecture_constraints.yaml — Tekhton Dependency Constraint Manifest
+#
+# Declarative dependency rules for your project. Two purposes:
+# 1. The validation_command runs deterministically in the build gate
+# 2. The architect agent reads the layer definitions during audits
+#
+# Copy this to your project root and customize for your architecture.
+
+# Command that validates import/dependency constraints.
+# Must exit 0 if all constraints pass, nonzero otherwise.
+# Pipeline calls this as part of the build gate.
+# Set to "" or omit to skip deterministic enforcement (constraints are still
+# used by the architect agent for reasoning).
+validation_command: ".claude/scripts/check_imports.sh"
+
+# Layer definitions — used by the architect agent to understand your
+# architecture when auditing drift observations. Also serves as
+# documentation for the validation script's rules.
+layers:
+  - name: "engine/rules"
+    description: "Game rule evaluation — pure functions, no state mutation"
+    may_depend_on:
+      - "engine/state"
+      - "core/config"
+    must_not_depend_on:
+      - "features"
+      - "persistence"
+
+  - name: "engine/state"
+    description: "Immutable game state models"
+    may_depend_on:
+      - "core/config"
+      - "models"
+    must_not_depend_on:
+      - "features"
+      - "persistence"
+      - "engine/rules"
+      - "engine/actions"
+
+  - name: "engine/actions"
+    description: "State transitions — the only code that mutates state"
+    may_depend_on:
+      - "engine/state"
+      - "engine/rules"
+      - "core/config"
+    must_not_depend_on:
+      - "features"
+      - "persistence"
+
+  - name: "models"
+    description: "Domain models shared across features"
+    may_depend_on:
+      - "core/config"
+    must_not_depend_on:
+      - "features"
+      - "persistence"
+      - "engine"
+
+  - name: "core"
+    description: "Config, theme, utilities — no business logic"
+    may_depend_on: []
+    must_not_depend_on:
+      - "features"
+      - "persistence"
+      - "engine"
+      - "models"
+
+  - name: "features/*/providers"
+    description: "State management providers — bridge between engine and UI"
+    may_depend_on:
+      - "engine"
+      - "models"
+      - "core"
+      - "persistence"
+    must_not_depend_on: []
+
+  - name: "features/*/widgets"
+    description: "UI components"
+    may_depend_on:
+      - "features/*/providers"
+      - "core/theme"
+      - "models"
+    must_not_depend_on:
+      - "engine/rules"
+      - "engine/actions"
+      - "persistence"

--- a/examples/check_imports_dart.sh
+++ b/examples/check_imports_dart.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# =============================================================================
+# check_imports_dart.sh — Dart/Flutter dependency constraint validator
+#
+# Sample validation script for use with Tekhton's dependency constraint system.
+# Copy this to your project (e.g. .claude/scripts/check_imports.sh) and
+# customize the RULES array for your layer architecture.
+#
+# Exit 0 = all constraints pass, nonzero = violations found.
+#
+# Usage:
+#   bash .claude/scripts/check_imports.sh
+#   # or make executable and call directly:
+#   chmod +x .claude/scripts/check_imports.sh
+#   .claude/scripts/check_imports.sh
+# =============================================================================
+
+set -euo pipefail
+
+# --- Configuration -----------------------------------------------------------
+# Each rule is: "source_glob|forbidden_import_pattern|description"
+#
+# source_glob:              files to check (relative to project root)
+# forbidden_import_pattern: regex matched against Dart import paths
+# description:              human-readable explanation of the rule
+#
+# Customize these for your project's layer architecture.
+RULES=(
+    "lib/engine/rules/**/*.dart|package:[^/]+/features/|engine/rules must not import features"
+    "lib/engine/rules/**/*.dart|package:[^/]+/persistence/|engine/rules must not import persistence"
+    "lib/engine/state/**/*.dart|package:[^/]+/features/|engine/state must not import features"
+    "lib/engine/state/**/*.dart|package:[^/]+/persistence/|engine/state must not import persistence"
+    "lib/engine/actions/**/*.dart|package:[^/]+/features/|engine/actions must not import features"
+    "lib/models/**/*.dart|package:[^/]+/features/|models must not import features"
+    "lib/models/**/*.dart|package:[^/]+/persistence/|models must not import persistence"
+    "lib/core/**/*.dart|package:[^/]+/features/|core must not import features"
+    "lib/core/**/*.dart|package:[^/]+/persistence/|core must not import persistence"
+)
+
+# --- Validator ---------------------------------------------------------------
+
+VIOLATIONS=0
+VIOLATION_DETAILS=""
+
+for rule in "${RULES[@]}"; do
+    IFS='|' read -r source_glob forbidden_pattern description <<< "$rule"
+
+    # Convert glob to find-compatible search: extract base dir, search recursively
+    base_dir=$(echo "$source_glob" | sed 's|\*\*/.*||; s|/\*$||; s|\*.*||')
+    [ -d "$base_dir" ] || continue
+
+    # Find matching source files
+    while IFS= read -r -d '' file; do
+        # Extract import lines and check against forbidden pattern
+        while IFS= read -r line; do
+            if echo "$line" | grep -qE "$forbidden_pattern"; then
+                VIOLATIONS=$((VIOLATIONS + 1))
+                VIOLATION_DETAILS+="  ${file}: ${line}\n"
+                VIOLATION_DETAILS+="    Rule: ${description}\n\n"
+            fi
+        done < <(grep -E "^import " "$file" 2>/dev/null || true)
+    done < <(find "$base_dir" -name "*.dart" -print0 2>/dev/null || true)
+done
+
+# --- Report ------------------------------------------------------------------
+
+if [ "$VIOLATIONS" -gt 0 ]; then
+    echo "Dependency constraint check FAILED — ${VIOLATIONS} violation(s) found:"
+    echo ""
+    echo -e "$VIOLATION_DETAILS"
+    exit 1
+fi
+
+echo "Dependency constraint check passed — no violations."
+exit 0

--- a/examples/check_imports_python.sh
+++ b/examples/check_imports_python.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# =============================================================================
+# check_imports_python.sh — Python dependency constraint validator
+#
+# Sample validation script for use with Tekhton's dependency constraint system.
+# Copy this to your project (e.g. .claude/scripts/check_imports.sh) and
+# customize the RULES array for your layer architecture.
+#
+# Exit 0 = all constraints pass, nonzero = violations found.
+#
+# Usage:
+#   bash .claude/scripts/check_imports.sh
+# =============================================================================
+
+set -euo pipefail
+
+# --- Configuration -----------------------------------------------------------
+# Each rule is: "source_glob|forbidden_import_pattern|description"
+#
+# source_glob:              files to check (relative to project root)
+# forbidden_import_pattern: regex matched against Python import statements
+# description:              human-readable explanation of the rule
+#
+# Customize these for your project's layer architecture.
+RULES=(
+    "src/domain/**/*.py|from src\\.api|domain must not import api layer"
+    "src/domain/**/*.py|import src\\.api|domain must not import api layer"
+    "src/domain/**/*.py|from src\\.infrastructure|domain must not import infrastructure"
+    "src/domain/**/*.py|import src\\.infrastructure|domain must not import infrastructure"
+    "src/services/**/*.py|from src\\.api|services must not import api layer"
+    "src/services/**/*.py|import src\\.api|services must not import api layer"
+)
+
+# --- Validator ---------------------------------------------------------------
+
+VIOLATIONS=0
+VIOLATION_DETAILS=""
+
+for rule in "${RULES[@]}"; do
+    IFS='|' read -r source_glob forbidden_pattern description <<< "$rule"
+
+    # Convert glob to find-compatible search: extract base dir, search recursively
+    base_dir=$(echo "$source_glob" | sed 's|\*\*/.*||; s|/\*$||; s|\*.*||')
+    [ -d "$base_dir" ] || continue
+
+    # Find matching source files
+    while IFS= read -r -d '' file; do
+        # Check both 'import x' and 'from x import y' lines
+        while IFS= read -r line; do
+            if echo "$line" | grep -qE "$forbidden_pattern"; then
+                VIOLATIONS=$((VIOLATIONS + 1))
+                VIOLATION_DETAILS+="  ${file}: ${line}\n"
+                VIOLATION_DETAILS+="    Rule: ${description}\n\n"
+            fi
+        done < <(grep -nE "^(import |from )" "$file" 2>/dev/null || true)
+    done < <(find "$base_dir" -name "*.py" -print0 2>/dev/null || true)
+done
+
+# --- Report ------------------------------------------------------------------
+
+if [ "$VIOLATIONS" -gt 0 ]; then
+    echo "Dependency constraint check FAILED — ${VIOLATIONS} violation(s) found:"
+    echo ""
+    echo -e "$VIOLATION_DETAILS"
+    exit 1
+fi
+
+echo "Dependency constraint check passed — no violations."
+exit 0

--- a/examples/check_imports_typescript.sh
+++ b/examples/check_imports_typescript.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# =============================================================================
+# check_imports_typescript.sh — TypeScript/JavaScript dependency constraint validator
+#
+# Sample validation script for use with Tekhton's dependency constraint system.
+# Copy this to your project (e.g. .claude/scripts/check_imports.sh) and
+# customize the RULES array for your layer architecture.
+#
+# Exit 0 = all constraints pass, nonzero = violations found.
+#
+# Usage:
+#   bash .claude/scripts/check_imports.sh
+# =============================================================================
+
+set -euo pipefail
+
+# --- Configuration -----------------------------------------------------------
+# Each rule is: "source_glob|forbidden_import_pattern|description"
+#
+# source_glob:              files to check (relative to project root)
+# forbidden_import_pattern: regex matched against import/require paths
+# description:              human-readable explanation of the rule
+#
+# Customize these for your project's layer architecture.
+RULES=(
+    "src/domain/**/*.ts|from ['\"].*/(api|controllers)/|domain must not import api/controllers"
+    "src/domain/**/*.ts|require\\(['\"].*/(api|controllers)/|domain must not import api/controllers"
+    "src/domain/**/*.ts|from ['\"].*/(infrastructure|db)/|domain must not import infrastructure"
+    "src/services/**/*.ts|from ['\"].*/(api|controllers)/|services must not import api/controllers"
+    "src/services/**/*.ts|require\\(['\"].*/(api|controllers)/|services must not import api/controllers"
+)
+
+# --- Validator ---------------------------------------------------------------
+
+VIOLATIONS=0
+VIOLATION_DETAILS=""
+
+for rule in "${RULES[@]}"; do
+    IFS='|' read -r source_glob forbidden_pattern description <<< "$rule"
+
+    # Convert glob to find-compatible search: extract base dir, search recursively
+    base_dir=$(echo "$source_glob" | sed 's|\*\*/.*||; s|/\*$||; s|\*.*||')
+    [ -d "$base_dir" ] || continue
+
+    # Find matching source files (both .ts and .js)
+    while IFS= read -r -d '' file; do
+        # Check import/require lines
+        while IFS= read -r line; do
+            if echo "$line" | grep -qE "$forbidden_pattern"; then
+                VIOLATIONS=$((VIOLATIONS + 1))
+                VIOLATION_DETAILS+="  ${file}: ${line}\n"
+                VIOLATION_DETAILS+="    Rule: ${description}\n\n"
+            fi
+        done < <(grep -nE "^(import |.*require\()" "$file" 2>/dev/null || true)
+    done < <(find "$base_dir" \( -name "*.ts" -o -name "*.js" -o -name "*.tsx" -o -name "*.jsx" \) -print0 2>/dev/null || true)
+done
+
+# --- Report ------------------------------------------------------------------
+
+if [ "$VIOLATIONS" -gt 0 ]; then
+    echo "Dependency constraint check FAILED — ${VIOLATIONS} violation(s) found:"
+    echo ""
+    echo -e "$VIOLATION_DETAILS"
+    exit 1
+fi
+
+echo "Dependency constraint check passed — no violations."
+exit 0

--- a/lib/gates.sh
+++ b/lib/gates.sh
@@ -63,6 +63,38 @@ EOF
         fi
     fi  # end BUILD_CHECK_CMD guard
 
+    # --- Dependency constraint validation (P5) ---
+    # Runs the validation_command from the constraint manifest, if configured.
+    # This is deterministic enforcement — no LLM judgment needed.
+    if [ -n "${DEPENDENCY_CONSTRAINTS_FILE:-}" ] && [ -f "${DEPENDENCY_CONSTRAINTS_FILE}" ]; then
+        local validation_cmd
+        validation_cmd=$(grep "^validation_command:" "${DEPENDENCY_CONSTRAINTS_FILE}" \
+            | sed 's/^validation_command: *//' | tr -d '"'"'" 2>/dev/null || true)
+
+        if [ -n "$validation_cmd" ]; then
+            log "Running dependency constraint validation: ${validation_cmd}"
+            local constraint_output=""
+            local constraint_exit=0
+            constraint_output=$(eval "$validation_cmd" 2>&1) || constraint_exit=$?
+
+            if [ "$constraint_exit" -ne 0 ]; then
+                warn "Build gate FAILED (${stage_label}) — dependency constraint violations:"
+                echo "$constraint_output"
+
+                # Append or create BUILD_ERRORS.md
+                cat >> BUILD_ERRORS.md << EOF
+
+## Dependency Constraint Violations
+\`\`\`
+${constraint_output}
+\`\`\`
+EOF
+                return 1
+            fi
+            log "Dependency constraints passed."
+        fi
+    fi
+
     log "Build gate PASSED (${stage_label})"
     [ -f BUILD_ERRORS.md ] && rm BUILD_ERRORS.md
     return 0

--- a/tests/test_dependency_constraints.sh
+++ b/tests/test_dependency_constraints.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+# Test: Dependency constraint validation in build gate — P5
+#       YAML command extraction, build gate pass/fail, error reporting
+set -euo pipefail
+
+TEKHTON_HOME="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+PROJECT_DIR="$TMPDIR"
+cd "$TMPDIR"
+
+# --- Minimal pipeline environment ---
+source "${TEKHTON_HOME}/lib/common.sh"
+
+# Overrides: ANALYZE_CMD always passes, no compile check
+ANALYZE_CMD="echo ok"
+ANALYZE_ERROR_PATTERN="NEVER_MATCH_THIS_STRING"
+BUILD_CHECK_CMD=""
+BUILD_ERROR_PATTERN="ERROR"
+DEPENDENCY_CONSTRAINTS_FILE=""
+
+source "${TEKHTON_HOME}/lib/gates.sh"
+
+FAIL=0
+
+assert_eq() {
+    local name="$1" expected="$2" actual="$3"
+    if [ "$expected" != "$actual" ]; then
+        echo "FAIL: $name — expected '$expected', got '$actual'"
+        FAIL=1
+    fi
+}
+
+assert_file_contains() {
+    local name="$1" file="$2" pattern="$3"
+    if ! grep -q "$pattern" "$file" 2>/dev/null; then
+        echo "FAIL: $name — pattern '$pattern' not found in $file"
+        FAIL=1
+    fi
+}
+
+assert_file_not_exists() {
+    local name="$1" file="$2"
+    if [ -f "$file" ]; then
+        echo "FAIL: $name — file '$file' should not exist"
+        FAIL=1
+    fi
+}
+
+# =============================================================================
+# Test 1: Build gate passes when no constraints configured
+# =============================================================================
+DEPENDENCY_CONSTRAINTS_FILE=""
+run_build_gate "test-no-constraints" > /dev/null 2>&1
+assert_eq "no constraints — passes" "0" "$?"
+
+# =============================================================================
+# Test 2: Build gate passes when constraint file does not exist
+# =============================================================================
+DEPENDENCY_CONSTRAINTS_FILE="nonexistent_constraints.yaml"
+run_build_gate "test-missing-file" > /dev/null 2>&1
+assert_eq "missing file — passes" "0" "$?"
+
+# =============================================================================
+# Test 3: Build gate passes when validation_command succeeds (exit 0)
+# =============================================================================
+cat > "${TMPDIR}/constraints.yaml" << 'EOF'
+validation_command: "echo all good && exit 0"
+
+layers:
+  - name: "engine"
+    must_not_depend_on:
+      - "features"
+EOF
+DEPENDENCY_CONSTRAINTS_FILE="${TMPDIR}/constraints.yaml"
+run_build_gate "test-passing-constraints" > /dev/null 2>&1
+assert_eq "passing constraints — passes" "0" "$?"
+assert_file_not_exists "passing — no BUILD_ERRORS.md" "BUILD_ERRORS.md"
+
+# =============================================================================
+# Test 4: Build gate fails when validation_command fails (exit 1)
+# =============================================================================
+cat > "${TMPDIR}/failing_constraints.yaml" << 'EOF'
+validation_command: "echo 'VIOLATION: engine/rules imports features' && exit 1"
+
+layers:
+  - name: "engine/rules"
+    must_not_depend_on:
+      - "features"
+EOF
+DEPENDENCY_CONSTRAINTS_FILE="${TMPDIR}/failing_constraints.yaml"
+local_exit=0
+run_build_gate "test-failing-constraints" > /dev/null 2>&1 || local_exit=$?
+assert_eq "failing constraints — fails" "1" "$local_exit"
+assert_file_contains "failing — BUILD_ERRORS.md has violations" \
+    "BUILD_ERRORS.md" "Dependency Constraint Violations"
+assert_file_contains "failing — BUILD_ERRORS.md has violation text" \
+    "BUILD_ERRORS.md" "engine/rules imports features"
+rm -f BUILD_ERRORS.md
+
+# =============================================================================
+# Test 5: Build gate passes when validation_command is empty/omitted
+# =============================================================================
+cat > "${TMPDIR}/no_cmd_constraints.yaml" << 'EOF'
+# No validation_command line — constraints are advisory only
+layers:
+  - name: "engine"
+    must_not_depend_on:
+      - "features"
+EOF
+DEPENDENCY_CONSTRAINTS_FILE="${TMPDIR}/no_cmd_constraints.yaml"
+run_build_gate "test-no-cmd" > /dev/null 2>&1
+assert_eq "no validation_command — passes" "0" "$?"
+
+# =============================================================================
+# Test 6: Build gate passes when validation_command is empty string
+# =============================================================================
+cat > "${TMPDIR}/empty_cmd_constraints.yaml" << 'EOF'
+validation_command: ""
+
+layers:
+  - name: "engine"
+    must_not_depend_on:
+      - "features"
+EOF
+DEPENDENCY_CONSTRAINTS_FILE="${TMPDIR}/empty_cmd_constraints.yaml"
+run_build_gate "test-empty-cmd" > /dev/null 2>&1
+assert_eq "empty validation_command — passes" "0" "$?"
+
+# =============================================================================
+# Test 7: YAML parsing extracts command with surrounding quotes
+# =============================================================================
+cat > "${TMPDIR}/quoted_constraints.yaml" << 'EOF'
+validation_command: "echo 'quoted command works' && exit 0"
+
+layers: []
+EOF
+DEPENDENCY_CONSTRAINTS_FILE="${TMPDIR}/quoted_constraints.yaml"
+run_build_gate "test-quoted-cmd" > /dev/null 2>&1
+assert_eq "quoted command — passes" "0" "$?"
+
+# =============================================================================
+# Test 8: YAML parsing extracts command with single quotes
+# =============================================================================
+cat > "${TMPDIR}/single_quoted_constraints.yaml" << 'EOF'
+validation_command: 'echo single-quoted && exit 0'
+
+layers: []
+EOF
+DEPENDENCY_CONSTRAINTS_FILE="${TMPDIR}/single_quoted_constraints.yaml"
+run_build_gate "test-single-quoted-cmd" > /dev/null 2>&1
+assert_eq "single-quoted command — passes" "0" "$?"
+
+# =============================================================================
+# Test 9: Constraint violation output captured in BUILD_ERRORS.md
+# =============================================================================
+cat > "${TMPDIR}/violation_script.sh" << 'SCRIPT'
+#!/usr/bin/env bash
+echo "line1: violation A"
+echo "line2: violation B"
+exit 1
+SCRIPT
+chmod +x "${TMPDIR}/violation_script.sh"
+cat > "${TMPDIR}/detail_constraints.yaml" << EOF
+validation_command: "${TMPDIR}/violation_script.sh"
+
+layers: []
+EOF
+DEPENDENCY_CONSTRAINTS_FILE="${TMPDIR}/detail_constraints.yaml"
+run_build_gate "test-detail-capture" > /dev/null 2>&1 || true
+assert_file_contains "detail — line1 captured" "BUILD_ERRORS.md" "violation A"
+assert_file_contains "detail — line2 captured" "BUILD_ERRORS.md" "violation B"
+rm -f BUILD_ERRORS.md
+
+# =============================================================================
+# Test 10: Architect prompt includes constraints when file exists
+# =============================================================================
+source "${TEKHTON_HOME}/lib/prompts.sh"
+
+# Set up all required template variables
+PROJECT_NAME="TestProject"
+TASK="test task"
+ARCHITECT_ROLE_FILE=".claude/agents/architect.md"
+ARCHITECTURE_FILE="ARCHITECTURE.md"
+PROJECT_RULES_FILE="CLAUDE.md"
+ARCHITECTURE_CONTENT="## Layers"
+ARCHITECTURE_LOG_CONTENT="## ADL"
+DRIFT_LOG_CONTENT="## Drift observations"
+DRIFT_OBSERVATION_COUNT="3"
+DEPENDENCY_CONSTRAINTS_CONTENT="layers:\n  - name: engine\n    must_not_depend_on: features"
+
+rendered=$(render_prompt "architect")
+if echo "$rendered" | grep -q "Dependency Constraints"; then
+    assert_eq "architect prompt includes constraints" "0" "0"
+else
+    echo "FAIL: architect prompt missing Dependency Constraints section"
+    FAIL=1
+fi
+
+# =============================================================================
+# Test 11: Architect prompt excludes constraints when empty
+# =============================================================================
+DEPENDENCY_CONSTRAINTS_CONTENT=""
+rendered=$(render_prompt "architect")
+if echo "$rendered" | grep -q "Dependency Constraints"; then
+    echo "FAIL: architect prompt should NOT include Dependency Constraints when empty"
+    FAIL=1
+fi
+
+# =============================================================================
+# Test 12: Sample Dart script passes on clean directory
+# =============================================================================
+mkdir -p "${TMPDIR}/lib/engine/rules"
+cat > "${TMPDIR}/lib/engine/rules/move_validator.dart" << 'DART'
+import 'package:lonn/engine/state/game_state.dart';
+import 'package:lonn/core/config/config_models.dart';
+DART
+if bash "${TEKHTON_HOME}/examples/check_imports_dart.sh" > /dev/null 2>&1; then
+    assert_eq "dart sample — clean imports pass" "0" "0"
+else
+    echo "FAIL: dart sample script failed on clean imports"
+    FAIL=1
+fi
+
+# =============================================================================
+# Test 13: Sample Dart script catches violations
+# =============================================================================
+cat > "${TMPDIR}/lib/engine/rules/bad_import.dart" << 'DART'
+import 'package:lonn/features/game/providers/game_provider.dart';
+DART
+dart_exit=0
+bash "${TEKHTON_HOME}/examples/check_imports_dart.sh" > /dev/null 2>&1 || dart_exit=$?
+assert_eq "dart sample — violation detected" "1" "$dart_exit"
+rm "${TMPDIR}/lib/engine/rules/bad_import.dart"
+
+# =============================================================================
+# Report results
+# =============================================================================
+if [ "$FAIL" -eq 0 ]; then
+    echo "All dependency constraint tests passed (13/13)"
+    exit 0
+else
+    echo "Some dependency constraint tests FAILED"
+    exit 1
+fi


### PR DESCRIPTION
- Add constraint validation step to run_build_gate() in lib/gates.sh Extracts validation_command from architecture_constraints.yaml and runs it after analyze + compile checks. Nonzero exit fails the gate.
- Create sample validation scripts in examples/:
  - check_imports_dart.sh (Dart/Flutter)
  - check_imports_python.sh (Python)
  - check_imports_typescript.sh (TypeScript/JS)
  - architecture_constraints.yaml (sample manifest)
- Add 13 tests covering:
  - Build gate pass/fail with constraints configured/unconfigured
  - YAML command extraction with various quoting styles
  - Violation output captured in BUILD_ERRORS.md
  - Architect prompt includes/excludes constraints conditionally
  - Sample Dart script detects violations on bad imports
- Update ARCHITECTURE.md with constraint system docs
- Update CLAUDE.md with examples/ directory listing

P5 acceptance criteria:
- Constraint manifest format documented and parseable
- Build gate runs validation_command when configured
- Violations fail build gate with clear error messages
- Architect agent reads constraints during audit (P4 infra)
- Pipeline works normally when unconfigured (opt-in)
- Sample validation scripts work for Dart