### PR TITLE
Agent Exit Detection

### DIFF
--- a/lib/agent.sh
+++ b/lib/agent.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # =============================================================================
-# agent.sh — Agent invocation wrapper with metrics tracking
+# agent.sh — Agent invocation wrapper with metrics tracking + exit detection
 #
 # Sourced by tekhton.sh — do not run directly.
 # Expects: TOTAL_TURNS, TOTAL_TIME, STAGE_SUMMARY (set by caller)
@@ -12,6 +12,14 @@
 : "${TOTAL_TURNS:=0}"
 : "${TOTAL_TIME:=0}"
 : "${STAGE_SUMMARY:=}"
+
+# --- Agent exit detection globals --------------------------------------------
+# Set after every run_agent() call. Callers inspect these to decide next steps.
+
+LAST_AGENT_TURNS=0         # Turns the agent actually used
+LAST_AGENT_EXIT_CODE=0     # claude CLI exit code
+LAST_AGENT_ELAPSED=0       # Wall-clock seconds
+LAST_AGENT_NULL_RUN=false  # true if agent likely died without doing work
 
 # --- Run summary -------------------------------------------------------------
 
@@ -104,4 +112,78 @@ run_agent() {
     # Store per-stage for summary
     STAGE_SUMMARY="${STAGE_SUMMARY}\n  ${label}: ${turns_display} turns, ${mins}m${secs}s"
 
+    # --- Agent exit detection ------------------------------------------------
+    # Populate LAST_AGENT_* globals so callers can check for null runs.
+
+    LAST_AGENT_TURNS="$turns_used"
+    LAST_AGENT_EXIT_CODE="$agent_exit"
+    LAST_AGENT_ELAPSED="$elapsed"
+    LAST_AGENT_NULL_RUN=false
+
+    # Null run heuristic: agent used very few turns (≤2) OR exited non-zero
+    # with zero turns. This typically means it died during discovery/search.
+    local null_threshold="${AGENT_NULL_RUN_THRESHOLD:-2}"
+    if [ "$turns_used" -le "$null_threshold" ] && [ "$agent_exit" -ne 0 ]; then
+        LAST_AGENT_NULL_RUN=true
+        warn "[$label] NULL RUN DETECTED — agent used ${turns_used} turn(s) and exited ${agent_exit}."
+        warn "[$label] The agent likely died during initial discovery/file search."
+    elif [ "$turns_used" -eq 0 ]; then
+        LAST_AGENT_NULL_RUN=true
+        warn "[$label] NULL RUN DETECTED — agent used 0 turns."
+    fi
+}
+
+# =============================================================================
+# NULL RUN DETECTION HELPERS
+# Call these after run_agent() to check if the agent accomplished anything.
+# =============================================================================
+
+# was_null_run — returns 0 (true) if the last agent invocation was a null run.
+# A null run is one where the agent died before accomplishing meaningful work.
+was_null_run() {
+    [ "$LAST_AGENT_NULL_RUN" = true ]
+}
+
+# check_agent_output — verifies an agent produced its expected output file and
+# made git changes. Returns 0 if the agent produced meaningful work.
+#
+# Usage:  check_agent_output "CODER_SUMMARY.md" "Coder"
+# Returns: 0 if output file exists AND (git has changes OR output file has content)
+#          1 if null run or no meaningful output
+check_agent_output() {
+    local expected_file="$1"
+    local label="$2"
+
+    # If the agent was already flagged as a null run, fail immediately
+    if was_null_run; then
+        warn "[$label] Agent was a null run — no output expected."
+        return 1
+    fi
+
+    # Check for expected output file
+    if [ ! -f "$expected_file" ]; then
+        warn "[$label] Expected output file '${expected_file}' not found."
+        return 1
+    fi
+
+    # Check if the file has meaningful content (more than just a header)
+    local line_count
+    line_count=$(wc -l < "$expected_file" | tr -d '[:space:]')
+    if [ "$line_count" -lt 3 ]; then
+        warn "[$label] Output file '${expected_file}' has only ${line_count} line(s) — likely a stub."
+        return 1
+    fi
+
+    # Check for git changes (the agent might have produced a report but changed no code)
+    local has_changes=false
+    if ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; then
+        has_changes=true
+    fi
+
+    if [ "$has_changes" = false ] && [ "$line_count" -lt 5 ]; then
+        warn "[$label] No git changes and minimal output — agent may not have accomplished anything."
+        return 1
+    fi
+
+    return 0
 }

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -78,6 +78,20 @@ load_config() {
     : "${CLAUDE_ARCHITECT_MODEL:=${CLAUDE_STANDARD_MODEL}}"
     : "${DEPENDENCY_CONSTRAINTS_FILE:=}"
 
+    # --- Agent exit detection defaults ---
+    : "${AGENT_NULL_RUN_THRESHOLD:=2}"       # Turns ≤ this + non-zero exit = null run
+
+    # --- Dynamic turn limit defaults ---
+    # Bounds for scout-recommended turn adjustments. The scout suggests a value;
+    # the pipeline clamps it to [min, max]. Set to 0 to disable dynamic limits.
+    : "${DYNAMIC_TURNS_ENABLED:=true}"
+    : "${CODER_MIN_TURNS:=15}"
+    : "${CODER_MAX_TURNS_CAP:=200}"
+    : "${REVIEWER_MIN_TURNS:=5}"
+    : "${REVIEWER_MAX_TURNS_CAP:=30}"
+    : "${TESTER_MIN_TURNS:=10}"
+    : "${TESTER_MAX_TURNS_CAP:=100}"
+
     # Milestone overrides — defaults to 2x normal if not specified
     : "${MILESTONE_MAX_REVIEW_CYCLES:=$(( MAX_REVIEW_CYCLES * 2 ))}"
     : "${MILESTONE_CODER_MAX_TURNS:=$(( CODER_MAX_TURNS * 2 ))}"

--- a/lib/turns.sh
+++ b/lib/turns.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# =============================================================================
+# turns.sh — Dynamic turn limit estimation
+#
+# Sourced by tekhton.sh — do not run directly.
+# Expects: DYNAMIC_TURNS_ENABLED, *_MIN_TURNS, *_MAX_TURNS_CAP (from config.sh)
+# Expects: CODER_MAX_TURNS, REVIEWER_MAX_TURNS, TESTER_MAX_TURNS (from config.sh)
+# Expects: log(), warn() from common.sh
+#
+# Provides:
+#   parse_scout_complexity  — read SCOUT_REPORT.md complexity section
+#   apply_scout_turn_limits — set ADJUSTED_*_TURNS from scout recommendation
+#   estimate_review_turns   — estimate reviewer turns from coder output
+#   estimate_tester_turns   — estimate tester turns from coder output
+#   clamp_turns             — clamp a value to [min, max]
+# =============================================================================
+
+# --- Clamp helper ------------------------------------------------------------
+
+# clamp_turns VALUE MIN MAX — returns VALUE clamped to [MIN, MAX]
+clamp_turns() {
+    local value="$1" min="$2" max="$3"
+    if [ "$value" -lt "$min" ] 2>/dev/null; then
+        echo "$min"
+    elif [ "$value" -gt "$max" ] 2>/dev/null; then
+        echo "$max"
+    else
+        echo "$value"
+    fi
+}
+
+# --- Parse scout complexity estimate -----------------------------------------
+
+# Reads SCOUT_REPORT.md and extracts complexity fields into global variables.
+# Sets: SCOUT_FILES_TO_MODIFY, SCOUT_LINES_OF_CHANGE, SCOUT_INTERCONNECTED,
+#       SCOUT_REC_CODER_TURNS, SCOUT_REC_REVIEWER_TURNS, SCOUT_REC_TESTER_TURNS
+# Returns 0 if complexity section was found and parsed, 1 otherwise.
+parse_scout_complexity() {
+    local report="${1:-SCOUT_REPORT.md}"
+
+    SCOUT_FILES_TO_MODIFY=0
+    SCOUT_LINES_OF_CHANGE=0
+    SCOUT_INTERCONNECTED="unknown"
+    SCOUT_REC_CODER_TURNS=0
+    SCOUT_REC_REVIEWER_TURNS=0
+    SCOUT_REC_TESTER_TURNS=0
+
+    if [ ! -f "$report" ]; then
+        return 1
+    fi
+
+    # Extract the Complexity Estimate section
+    local section
+    section=$(awk '/^## Complexity Estimate/{found=1; next} found && /^##/{exit} found{print}' \
+        "$report" 2>/dev/null || true)
+
+    if [ -z "$section" ]; then
+        return 1
+    fi
+
+    # Parse each field — extract the numeric value after the colon
+    SCOUT_FILES_TO_MODIFY=$(echo "$section" | grep -i "^Files to modify:" | sed 's/.*: *//' | tr -dc '0-9' || echo "0")
+    SCOUT_LINES_OF_CHANGE=$(echo "$section" | grep -i "^Estimated lines" | sed 's/.*: *//' | tr -dc '0-9' || echo "0")
+    SCOUT_INTERCONNECTED=$(echo "$section" | grep -i "^Interconnected" | sed 's/.*: *//' | tr -d '[:space:]' || echo "unknown")
+    SCOUT_REC_CODER_TURNS=$(echo "$section" | grep -i "^Recommended coder" | sed 's/.*: *//' | tr -dc '0-9' || echo "0")
+    SCOUT_REC_REVIEWER_TURNS=$(echo "$section" | grep -i "^Recommended reviewer" | sed 's/.*: *//' | tr -dc '0-9' || echo "0")
+    SCOUT_REC_TESTER_TURNS=$(echo "$section" | grep -i "^Recommended tester" | sed 's/.*: *//' | tr -dc '0-9' || echo "0")
+
+    # Validate — at least coder turns must be non-zero
+    [ "${SCOUT_REC_CODER_TURNS:-0}" -gt 0 ] 2>/dev/null
+}
+
+# --- Apply scout recommendations to turn limits -----------------------------
+
+# Reads scout complexity and sets ADJUSTED_*_TURNS variables.
+# Falls back to configured defaults if scout data is missing or dynamic turns disabled.
+apply_scout_turn_limits() {
+    # Initialize adjusted values to defaults
+    ADJUSTED_CODER_TURNS="$CODER_MAX_TURNS"
+    ADJUSTED_REVIEWER_TURNS="$REVIEWER_MAX_TURNS"
+    ADJUSTED_TESTER_TURNS="$TESTER_MAX_TURNS"
+
+    if [ "${DYNAMIC_TURNS_ENABLED}" != "true" ]; then
+        log "Dynamic turn limits disabled — using configured defaults."
+        return
+    fi
+
+    local report="${1:-SCOUT_REPORT.md}"
+    if ! parse_scout_complexity "$report"; then
+        log "No scout complexity estimate found — using configured defaults."
+        return
+    fi
+
+    log "Scout complexity estimate:"
+    log "  Files to modify: ${SCOUT_FILES_TO_MODIFY}"
+    log "  Estimated lines: ${SCOUT_LINES_OF_CHANGE}"
+    log "  Interconnected:  ${SCOUT_INTERCONNECTED}"
+    log "  Recommended:     coder=${SCOUT_REC_CODER_TURNS}, reviewer=${SCOUT_REC_REVIEWER_TURNS}, tester=${SCOUT_REC_TESTER_TURNS}"
+
+    # Apply scout recommendation, clamped to configured bounds
+    if [ "${SCOUT_REC_CODER_TURNS:-0}" -gt 0 ] 2>/dev/null; then
+        ADJUSTED_CODER_TURNS=$(clamp_turns "$SCOUT_REC_CODER_TURNS" "$CODER_MIN_TURNS" "$CODER_MAX_TURNS_CAP")
+        log "Coder turns: ${CODER_MAX_TURNS} (configured) → ${ADJUSTED_CODER_TURNS} (scout-adjusted)"
+    fi
+
+    if [ "${SCOUT_REC_REVIEWER_TURNS:-0}" -gt 0 ] 2>/dev/null; then
+        ADJUSTED_REVIEWER_TURNS=$(clamp_turns "$SCOUT_REC_REVIEWER_TURNS" "$REVIEWER_MIN_TURNS" "$REVIEWER_MAX_TURNS_CAP")
+        log "Reviewer turns: ${REVIEWER_MAX_TURNS} (configured) → ${ADJUSTED_REVIEWER_TURNS} (scout-adjusted)"
+    fi
+
+    if [ "${SCOUT_REC_TESTER_TURNS:-0}" -gt 0 ] 2>/dev/null; then
+        ADJUSTED_TESTER_TURNS=$(clamp_turns "$SCOUT_REC_TESTER_TURNS" "$TESTER_MIN_TURNS" "$TESTER_MAX_TURNS_CAP")
+        log "Tester turns: ${TESTER_MAX_TURNS} (configured) → ${ADJUSTED_TESTER_TURNS} (scout-adjusted)"
+    fi
+}
+
+# --- Estimate turns from coder output ----------------------------------------
+
+# When no scout ran (e.g., --start-at review), estimate reviewer/tester turns
+# based on the size of coder output. This is a rough heuristic.
+estimate_post_coder_turns() {
+    if [ "${DYNAMIC_TURNS_ENABLED}" != "true" ]; then
+        ADJUSTED_REVIEWER_TURNS="${ADJUSTED_REVIEWER_TURNS:-$REVIEWER_MAX_TURNS}"
+        ADJUSTED_TESTER_TURNS="${ADJUSTED_TESTER_TURNS:-$TESTER_MAX_TURNS}"
+        return
+    fi
+
+    # If scout already set these, don't override
+    if [ "${SCOUT_REC_REVIEWER_TURNS:-0}" -gt 0 ] 2>/dev/null; then
+        return
+    fi
+
+    local files_modified=0
+    local diff_lines=0
+
+    # Count files modified from CODER_SUMMARY.md
+    if [ -f "CODER_SUMMARY.md" ]; then
+        files_modified=$(awk '/^## Files (Modified|created or modified)/{found=1; next} found && /^##/{exit} found && /^[-*]/{count++} END{print count+0}' \
+            CODER_SUMMARY.md 2>/dev/null || echo "0")
+    fi
+
+    # Count git diff stat lines
+    if ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; then
+        diff_lines=$(git diff --stat HEAD 2>/dev/null | tail -1 | grep -o '[0-9]* insertion' | tr -dc '0-9' || echo "0")
+        local del_lines
+        del_lines=$(git diff --stat HEAD 2>/dev/null | tail -1 | grep -o '[0-9]* deletion' | tr -dc '0-9' || echo "0")
+        diff_lines=$(( ${diff_lines:-0} + ${del_lines:-0} ))
+    fi
+
+    # Heuristic: more files/lines → more review/test turns needed
+    local estimated_reviewer estimated_tester
+    if [ "$files_modified" -le 3 ] && [ "$diff_lines" -le 100 ]; then
+        estimated_reviewer=8
+        estimated_tester=20
+    elif [ "$files_modified" -le 8 ] && [ "$diff_lines" -le 500 ]; then
+        estimated_reviewer=12
+        estimated_tester=35
+    else
+        estimated_reviewer=18
+        estimated_tester=50
+    fi
+
+    ADJUSTED_REVIEWER_TURNS=$(clamp_turns "$estimated_reviewer" "$REVIEWER_MIN_TURNS" "$REVIEWER_MAX_TURNS_CAP")
+    ADJUSTED_TESTER_TURNS=$(clamp_turns "$estimated_tester" "$TESTER_MIN_TURNS" "$TESTER_MAX_TURNS_CAP")
+
+    log "Post-coder turn estimate (${files_modified} files, ~${diff_lines} diff lines):"
+    log "  Reviewer: ${ADJUSTED_REVIEWER_TURNS}, Tester: ${ADJUSTED_TESTER_TURNS}"
+}

--- a/prompts/scout.prompt.md
+++ b/prompts/scout.prompt.md
@@ -1,11 +1,19 @@
 You are a code scout for the {{PROJECT_NAME}} project.
 
 ## Your Only Job
-Find the files relevant to these bug reports. Do not fix anything. Do not read entire files.
+Find the files relevant to the task below. Do not fix anything. Do not read entire files.
 Use `find`, `grep`, and `ls` to locate files by name and keyword. Read only the top ~30 lines of each candidate file to confirm relevance.
 
-## Bug Reports
+## Task
+{{TASK}}
+{{IF:HUMAN_NOTES_CONTENT}}
+
+## Human Notes
 {{HUMAN_NOTES_CONTENT}}
+{{ENDIF:HUMAN_NOTES_CONTENT}}
+{{IF:ARCHITECTURE_BLOCK}}
+{{ARCHITECTURE_BLOCK}}
+{{ENDIF:ARCHITECTURE_BLOCK}}
 
 ## Output
 Write a file called `SCOUT_REPORT.md` in this exact format:
@@ -19,7 +27,28 @@ Write a file called `SCOUT_REPORT.md` in this exact format:
 - ClassName / methodName — file it lives in
 
 ## Suspected Root Cause Areas
-- One line per bug describing which file/method is the likely culprit
+- One line per item describing which file/method is the likely culprit
+
+## Complexity Estimate
+Files to modify: N
+Estimated lines of change: N
+Interconnected systems: low | medium | high
+Recommended coder turns: N
+Recommended reviewer turns: N
+Recommended tester turns: N
 ```
 
-Do not read more than 5 files. Do not write any code. Just map the territory.
+### Complexity Estimation Guidelines
+- **Files to modify**: Count distinct files that will need changes
+- **Lines of change**: Rough estimate of total lines added + modified + deleted
+- **Interconnected systems**: How many distinct modules/systems are touched
+  - `low` = 1-2 files in one module
+  - `medium` = 3-8 files across 2-3 modules
+  - `high` = 8+ files across 4+ modules
+- **Recommended turns**: Based on complexity:
+  - Simple bug fix (1-2 files): coder 15-25, reviewer 5-8, tester 15-25
+  - Medium feature (3-8 files): coder 30-50, reviewer 8-12, tester 25-40
+  - Large feature (8+ files): coder 50-80, reviewer 10-15, tester 40-60
+  - Milestone (cross-cutting): coder 80-120, reviewer 12-20, tester 50-80
+
+Do not read more than 10 files. Do not write any code. Just map the territory.

--- a/stages/coder.sh
+++ b/stages/coder.sh
@@ -30,12 +30,24 @@ run_stage_coder() {
         if echo "$TASK$(extract_human_notes)" | grep -qiE "extend|add to|modify|integrate|update|change|existing"; then
             SHOULD_SCOUT=true
         fi
+    elif [ "${DYNAMIC_TURNS_ENABLED}" = "true" ]; then
+        # Scout for complexity estimation even without human notes
+        SHOULD_SCOUT=true
     fi
 
     if [ "$SHOULD_SCOUT" = true ]; then
-        log "Running scout agent to locate relevant files before coder invocation..."
+        log "Running scout agent to locate relevant files and estimate complexity..."
 
         HUMAN_NOTES_CONTENT=$(extract_human_notes)
+
+        # Build architecture block for scout if available
+        ARCHITECTURE_BLOCK=""
+        if [ -f "${ARCHITECTURE_FILE}" ]; then
+            ARCHITECTURE_BLOCK="
+## Architecture Map (use this to find files — do NOT explore blindly)
+$(cat "${ARCHITECTURE_FILE}")"
+        fi
+
         SCOUT_PROMPT=$(render_prompt "scout")
 
         run_agent \
@@ -48,6 +60,10 @@ run_stage_coder() {
         if [ -f "SCOUT_REPORT.md" ]; then
             print_run_summary
             success "Scout agent finished. Relevant files located."
+
+            # Parse complexity estimate before archiving the report
+            apply_scout_turn_limits "SCOUT_REPORT.md"
+
             BUG_SCOUT_CONTEXT="
 ## Scout Report (pre-located relevant files — read THESE files, not the whole project)
 $(cat SCOUT_REPORT.md)
@@ -55,6 +71,9 @@ $(cat SCOUT_REPORT.md)
             # Archive scout report with the run
             cp "SCOUT_REPORT.md" "${LOG_DIR}/${TIMESTAMP}_SCOUT_REPORT.md"
             rm "SCOUT_REPORT.md"
+        elif was_null_run; then
+            print_run_summary
+            warn "Scout was a null run (${LAST_AGENT_TURNS} turns) — coder will explore independently."
         else
             warn "Scout agent did not produce SCOUT_REPORT.md — coder will explore independently."
         fi
@@ -175,6 +194,30 @@ $(cat TESTER_REPORT.md)"
         "$LOG_FILE"
     print_run_summary
     success "Coder agent finished."
+
+    # --- Null run detection ---------------------------------------------------
+
+    if was_null_run; then
+        error "Coder agent was a null run — it died before doing meaningful work."
+        error "This usually means the agent couldn't find files, hit a permission error,"
+        error "or the prompt was too complex for initial discovery."
+
+        # Reset claimed notes — coder didn't produce any work
+        if [ "$HUMAN_NOTE_COUNT" -gt 0 ]; then
+            resolve_human_notes
+        fi
+
+        write_pipeline_state \
+            "coder" \
+            "null_run" \
+            "--start-at coder" \
+            "$TASK" \
+            "Agent used ${LAST_AGENT_TURNS} turn(s) and exited ${LAST_AGENT_EXIT_CODE}. Likely died during initial file discovery. Consider: narrower task description, adding a SCOUT_REPORT.md manually, or checking agent logs."
+
+        error "State saved with exit reason 'null_run'. Check the log: ${LOG_FILE}"
+        error "Re-run with a more specific task description or add context files."
+        exit 1
+    fi
 
     # --- Post-coder validation -----------------------------------------------
 

--- a/stages/review.sh
+++ b/stages/review.sh
@@ -19,6 +19,9 @@
 run_stage_review() {
     header "Stage 2 / 3 — Reviewer"
 
+    # Estimate review/tester turns from coder output if scout didn't already set them
+    estimate_post_coder_turns
+
     REVIEW_CYCLE=0
     VERDICT="CHANGES_REQUIRED"
 
@@ -38,11 +41,27 @@ run_stage_review() {
         run_agent \
             "Reviewer (cycle ${REVIEW_CYCLE})" \
             "$CLAUDE_STANDARD_MODEL" \
-            "$REVIEWER_MAX_TURNS" \
+            "${ADJUSTED_REVIEWER_TURNS:-$REVIEWER_MAX_TURNS}" \
             "$REVIEWER_PROMPT" \
             "$LOG_FILE"
         print_run_summary
         success "Reviewer finished."
+
+        # Check for null run before parsing output
+        if was_null_run; then
+            warn "Reviewer was a null run (${LAST_AGENT_TURNS} turns, exit ${LAST_AGENT_EXIT_CODE})."
+            warn "Skipping review parse — will retry on next cycle or fail at max cycles."
+            VERDICT="CHANGES_REQUIRED"
+            if [ "$REVIEW_CYCLE" -ge "$MAX_REVIEW_CYCLES" ]; then
+                error "Reviewer null run at max review cycles — cannot proceed."
+                write_pipeline_state "review" "null_run" \
+                    "${MILESTONE_MODE:+--milestone }--start-at review" \
+                    "$TASK" \
+                    "Reviewer agent died without producing output (${LAST_AGENT_TURNS} turns). Check logs."
+                exit 1
+            fi
+            continue
+        fi
 
         if [ ! -f "REVIEWER_REPORT.md" ]; then
             error "Reviewer did not produce REVIEWER_REPORT.md. Check the log: ${LOG_FILE}"

--- a/stages/tester.sh
+++ b/stages/tester.sh
@@ -25,14 +25,29 @@ run_stage_tester() {
         TESTER_PROMPT=$(render_prompt "tester")
     fi
 
-    log "Invoking tester agent (max ${TESTER_MAX_TURNS} turns)..."
+    log "Invoking tester agent (max ${ADJUSTED_TESTER_TURNS:-$TESTER_MAX_TURNS} turns)..."
     run_agent \
         "Tester" \
         "$CLAUDE_TESTER_MODEL" \
-        "$TESTER_MAX_TURNS" \
+        "${ADJUSTED_TESTER_TURNS:-$TESTER_MAX_TURNS}" \
         "$TESTER_PROMPT" \
         "$LOG_FILE"
     TESTER_EXIT=$?
+
+    # --- Null run detection ---------------------------------------------------
+
+    if was_null_run; then
+        warn "Tester was a null run (${LAST_AGENT_TURNS} turns, exit ${LAST_AGENT_EXIT_CODE})."
+        warn "The tester agent died before writing any tests."
+        write_pipeline_state \
+            "tester" \
+            "null_run" \
+            "--start-at test" \
+            "${TASK}" \
+            "Tester agent used ${LAST_AGENT_TURNS} turn(s) and exited ${LAST_AGENT_EXIT_CODE}. Likely died during discovery. Check logs: ${LOG_FILE}"
+        warn "State saved — re-run with: $0 --start-at test \"${TASK}\""
+        return
+    fi
 
     # --- Post-tester validation ----------------------------------------------
 

--- a/tekhton.sh
+++ b/tekhton.sh
@@ -171,6 +171,7 @@ source "${TEKHTON_HOME}/lib/prompts.sh"
 source "${TEKHTON_HOME}/lib/gates.sh"
 source "${TEKHTON_HOME}/lib/hooks.sh"
 source "${TEKHTON_HOME}/lib/drift.sh"
+source "${TEKHTON_HOME}/lib/turns.sh"
 
 # Stage implementations
 source "${TEKHTON_HOME}/stages/architect.sh"

--- a/templates/pipeline.conf.example
+++ b/templates/pipeline.conf.example
@@ -131,6 +131,25 @@ ARCHITECT_MAX_TURNS=25
 # Dependency constraint manifest (empty = skip). See P5 for format.
 DEPENDENCY_CONSTRAINTS_FILE=""
 
+# --- Agent exit detection ----------------------------------------------------
+# When an agent uses ≤ this many turns AND exits non-zero, it's flagged as a
+# "null run" (died during discovery without doing productive work).
+# AGENT_NULL_RUN_THRESHOLD=2
+
+# --- Dynamic turn limits ----------------------------------------------------
+# When enabled, the scout estimates task complexity and adjusts turn limits
+# for coder, reviewer, and tester stages. Recommended values are clamped to
+# [MIN, MAX_CAP] bounds. Set to false to always use the static limits above.
+DYNAMIC_TURNS_ENABLED=true
+
+# Bounds for dynamic turn adjustment (only used when DYNAMIC_TURNS_ENABLED=true)
+# CODER_MIN_TURNS=15
+# CODER_MAX_TURNS_CAP=200
+# REVIEWER_MIN_TURNS=5
+# REVIEWER_MAX_TURNS_CAP=30
+# TESTER_MIN_TURNS=10
+# TESTER_MAX_TURNS_CAP=100
+
 # --- Seed contracts ----------------------------------------------------------
 # Enable inline contract seeding (adds assertion comments to source)
 SEED_CONTRACTS_ENABLED=false

--- a/tests/test_agent_exit_detection.sh
+++ b/tests/test_agent_exit_detection.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# =============================================================================
+# test_agent_exit_detection.sh — Null run detection in run_agent wrapper
+#
+# Tests:
+#   1. LAST_AGENT_* globals are set after run_agent simulations
+#   2. was_null_run returns true for ≤2 turns + non-zero exit
+#   3. was_null_run returns false for normal runs
+#   4. check_agent_output detects missing/stub files
+#   5. Null run threshold is configurable
+# =============================================================================
+set -euo pipefail
+
+TEKHTON_HOME="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# --- Minimal pipeline globals ------------------------------------------------
+PROJECT_DIR="$TMPDIR"
+PROJECT_NAME="test-project"
+LOG_DIR="${TMPDIR}/logs"
+mkdir -p "$LOG_DIR"
+
+source "${TEKHTON_HOME}/lib/common.sh"
+source "${TEKHTON_HOME}/lib/agent.sh"
+
+cd "$TMPDIR"
+git init -q .
+
+FAIL=0
+
+assert_eq() {
+    local name="$1" expected="$2" actual="$3"
+    if [ "$expected" != "$actual" ]; then
+        echo "FAIL: $name — expected '$expected', got '$actual'"
+        FAIL=1
+    fi
+}
+
+# =============================================================================
+# Phase 1: LAST_AGENT_* globals — default state
+# =============================================================================
+
+assert_eq "1.1 default LAST_AGENT_TURNS" "0" "$LAST_AGENT_TURNS"
+assert_eq "1.2 default LAST_AGENT_EXIT_CODE" "0" "$LAST_AGENT_EXIT_CODE"
+assert_eq "1.3 default LAST_AGENT_ELAPSED" "0" "$LAST_AGENT_ELAPSED"
+assert_eq "1.4 default LAST_AGENT_NULL_RUN" "false" "$LAST_AGENT_NULL_RUN"
+
+# =============================================================================
+# Phase 2: was_null_run with direct manipulation
+# =============================================================================
+
+# 2.1: Simulate a null run — 0 turns
+LAST_AGENT_NULL_RUN=true
+if was_null_run; then
+    assert_eq "2.1 was_null_run true when flagged" "0" "0"
+else
+    echo "FAIL: 2.1 was_null_run should return true when LAST_AGENT_NULL_RUN=true"
+    FAIL=1
+fi
+
+# 2.2: Simulate a normal run
+LAST_AGENT_NULL_RUN=false
+if was_null_run; then
+    echo "FAIL: 2.2 was_null_run should return false when LAST_AGENT_NULL_RUN=false"
+    FAIL=1
+else
+    assert_eq "2.2 was_null_run false for normal run" "0" "0"
+fi
+
+# =============================================================================
+# Phase 3: check_agent_output — missing file
+# =============================================================================
+
+LAST_AGENT_NULL_RUN=false
+
+# 3.1: Missing output file
+if check_agent_output "NONEXISTENT.md" "Test" 2>/dev/null; then
+    echo "FAIL: 3.1 check_agent_output should fail for missing file"
+    FAIL=1
+else
+    assert_eq "3.1 check_agent_output fails for missing file" "0" "0"
+fi
+
+# 3.2: Stub file (only 1 line)
+echo "# Header only" > "${TMPDIR}/STUB.md"
+if check_agent_output "${TMPDIR}/STUB.md" "Test" 2>/dev/null; then
+    echo "FAIL: 3.2 check_agent_output should fail for stub file"
+    FAIL=1
+else
+    assert_eq "3.2 check_agent_output fails for stub file" "0" "0"
+fi
+
+# 3.3: File with content + git changes
+cat > "${TMPDIR}/GOOD_REPORT.md" << 'EOF'
+# Coder Summary
+## Status: COMPLETE
+## What Was Implemented
+Implemented the feature.
+## Files Modified
+- lib/foo.dart
+EOF
+echo "changed" > "${TMPDIR}/somefile.txt"
+git add -A && git commit -q -m "init"
+echo "modified" >> "${TMPDIR}/somefile.txt"
+
+if check_agent_output "${TMPDIR}/GOOD_REPORT.md" "Test" 2>/dev/null; then
+    assert_eq "3.3 check_agent_output passes with content + git changes" "0" "0"
+else
+    echo "FAIL: 3.3 check_agent_output should pass with content and git changes"
+    FAIL=1
+fi
+
+# 3.4: Null run flagged — check_agent_output fails immediately
+LAST_AGENT_NULL_RUN=true
+if check_agent_output "${TMPDIR}/GOOD_REPORT.md" "Test" 2>/dev/null; then
+    echo "FAIL: 3.4 check_agent_output should fail when null run flagged"
+    FAIL=1
+else
+    assert_eq "3.4 check_agent_output fails on null run" "0" "0"
+fi
+LAST_AGENT_NULL_RUN=false
+
+# =============================================================================
+# Phase 4: Null run threshold configuration
+# =============================================================================
+
+# 4.1: Default threshold (2) — 3 turns with non-zero exit should NOT be null run
+LAST_AGENT_TURNS=3
+LAST_AGENT_EXIT_CODE=1
+LAST_AGENT_NULL_RUN=false
+
+# Simulate the threshold check logic from run_agent
+null_threshold="${AGENT_NULL_RUN_THRESHOLD:-2}"
+if [ "$LAST_AGENT_TURNS" -le "$null_threshold" ] && [ "$LAST_AGENT_EXIT_CODE" -ne 0 ]; then
+    LAST_AGENT_NULL_RUN=true
+elif [ "$LAST_AGENT_TURNS" -eq 0 ]; then
+    LAST_AGENT_NULL_RUN=true
+fi
+assert_eq "4.1 3 turns + error is NOT null run at threshold 2" "false" "$LAST_AGENT_NULL_RUN"
+
+# 4.2: Raise threshold to 5 — 3 turns + non-zero exit should be null run
+LAST_AGENT_NULL_RUN=false
+AGENT_NULL_RUN_THRESHOLD=5
+null_threshold="${AGENT_NULL_RUN_THRESHOLD:-2}"
+if [ "$LAST_AGENT_TURNS" -le "$null_threshold" ] && [ "$LAST_AGENT_EXIT_CODE" -ne 0 ]; then
+    LAST_AGENT_NULL_RUN=true
+elif [ "$LAST_AGENT_TURNS" -eq 0 ]; then
+    LAST_AGENT_NULL_RUN=true
+fi
+assert_eq "4.2 3 turns + error IS null run at threshold 5" "true" "$LAST_AGENT_NULL_RUN"
+AGENT_NULL_RUN_THRESHOLD=2  # Reset
+
+# 4.3: 0 turns + exit 0 should still be null run (always suspicious)
+LAST_AGENT_TURNS=0
+LAST_AGENT_EXIT_CODE=0
+LAST_AGENT_NULL_RUN=false
+null_threshold="${AGENT_NULL_RUN_THRESHOLD:-2}"
+if [ "$LAST_AGENT_TURNS" -le "$null_threshold" ] && [ "$LAST_AGENT_EXIT_CODE" -ne 0 ]; then
+    LAST_AGENT_NULL_RUN=true
+elif [ "$LAST_AGENT_TURNS" -eq 0 ]; then
+    LAST_AGENT_NULL_RUN=true
+fi
+assert_eq "4.3 0 turns + exit 0 IS null run" "true" "$LAST_AGENT_NULL_RUN"
+
+# =============================================================================
+# Done
+# =============================================================================
+
+if [ "$FAIL" -ne 0 ]; then
+    exit 1
+fi
+exit 0

--- a/tests/test_dynamic_turn_limits.sh
+++ b/tests/test_dynamic_turn_limits.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+# =============================================================================
+# test_dynamic_turn_limits.sh — Scout-driven turn limit estimation
+#
+# Tests:
+#   1. clamp_turns clamps values to [min, max]
+#   2. parse_scout_complexity extracts fields from scout report
+#   3. parse_scout_complexity returns 1 when no report/section exists
+#   4. apply_scout_turn_limits applies clamped recommendations
+#   5. apply_scout_turn_limits falls back to defaults when disabled
+#   6. estimate_post_coder_turns estimates from file count / diff size
+#   7. Milestone mode caps override dynamic limits correctly
+# =============================================================================
+set -euo pipefail
+
+TEKHTON_HOME="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# --- Minimal pipeline globals ------------------------------------------------
+PROJECT_DIR="$TMPDIR"
+PROJECT_NAME="test-project"
+LOG_DIR="${TMPDIR}/logs"
+mkdir -p "$LOG_DIR"
+
+# Simulate loaded config values
+CODER_MAX_TURNS=35
+REVIEWER_MAX_TURNS=10
+TESTER_MAX_TURNS=30
+CODER_MIN_TURNS=15
+CODER_MAX_TURNS_CAP=200
+REVIEWER_MIN_TURNS=5
+REVIEWER_MAX_TURNS_CAP=30
+TESTER_MIN_TURNS=10
+TESTER_MAX_TURNS_CAP=100
+DYNAMIC_TURNS_ENABLED=true
+AGENT_NULL_RUN_THRESHOLD=2
+
+# Agent globals needed by turns.sh
+LAST_AGENT_TURNS=0
+LAST_AGENT_EXIT_CODE=0
+LAST_AGENT_ELAPSED=0
+LAST_AGENT_NULL_RUN=false
+TOTAL_TURNS=0
+TOTAL_TIME=0
+STAGE_SUMMARY=""
+
+source "${TEKHTON_HOME}/lib/common.sh"
+source "${TEKHTON_HOME}/lib/agent.sh"
+source "${TEKHTON_HOME}/lib/turns.sh"
+
+cd "$TMPDIR"
+git init -q .
+echo "init" > init.txt && git add -A && git commit -q -m "init"
+
+FAIL=0
+
+assert_eq() {
+    local name="$1" expected="$2" actual="$3"
+    if [ "$expected" != "$actual" ]; then
+        echo "FAIL: $name — expected '$expected', got '$actual'"
+        FAIL=1
+    fi
+}
+
+# =============================================================================
+# Phase 1: clamp_turns
+# =============================================================================
+
+assert_eq "1.1 clamp within range" "50" "$(clamp_turns 50 10 100)"
+assert_eq "1.2 clamp below min" "10" "$(clamp_turns 5 10 100)"
+assert_eq "1.3 clamp above max" "100" "$(clamp_turns 150 10 100)"
+assert_eq "1.4 clamp at min" "10" "$(clamp_turns 10 10 100)"
+assert_eq "1.5 clamp at max" "100" "$(clamp_turns 100 10 100)"
+
+# =============================================================================
+# Phase 2: parse_scout_complexity — valid report
+# =============================================================================
+
+cat > "${TMPDIR}/SCOUT_REPORT.md" << 'EOF'
+## Relevant Files
+- lib/engine/rules/move_validator.dart — validates card moves
+- lib/engine/state/game_state.dart — game state model
+
+## Key Symbols
+- MoveValidator / validateMove — move_validator.dart
+
+## Suspected Root Cause Areas
+- MoveValidator doesn't check stack size correctly
+
+## Complexity Estimate
+Files to modify: 5
+Estimated lines of change: 200
+Interconnected systems: medium
+Recommended coder turns: 40
+Recommended reviewer turns: 10
+Recommended tester turns: 30
+EOF
+
+if parse_scout_complexity "${TMPDIR}/SCOUT_REPORT.md"; then
+    assert_eq "2.1 files_to_modify" "5" "$SCOUT_FILES_TO_MODIFY"
+    assert_eq "2.2 lines_of_change" "200" "$SCOUT_LINES_OF_CHANGE"
+    assert_eq "2.3 interconnected" "medium" "$SCOUT_INTERCONNECTED"
+    assert_eq "2.4 rec_coder_turns" "40" "$SCOUT_REC_CODER_TURNS"
+    assert_eq "2.5 rec_reviewer_turns" "10" "$SCOUT_REC_REVIEWER_TURNS"
+    assert_eq "2.6 rec_tester_turns" "30" "$SCOUT_REC_TESTER_TURNS"
+else
+    echo "FAIL: 2.0 parse_scout_complexity should return 0 for valid report"
+    FAIL=1
+fi
+
+# =============================================================================
+# Phase 3: parse_scout_complexity — missing/invalid reports
+# =============================================================================
+
+# 3.1: No file
+if parse_scout_complexity "${TMPDIR}/NONEXISTENT.md" 2>/dev/null; then
+    echo "FAIL: 3.1 parse_scout_complexity should fail for missing file"
+    FAIL=1
+else
+    assert_eq "3.1 missing file returns 1" "0" "0"
+fi
+
+# 3.2: File without complexity section
+cat > "${TMPDIR}/MINIMAL_SCOUT.md" << 'EOF'
+## Relevant Files
+- lib/foo.dart — some file
+EOF
+
+if parse_scout_complexity "${TMPDIR}/MINIMAL_SCOUT.md" 2>/dev/null; then
+    echo "FAIL: 3.2 parse_scout_complexity should fail for report without complexity section"
+    FAIL=1
+else
+    assert_eq "3.2 no complexity section returns 1" "0" "0"
+fi
+
+# 3.3: Complexity section with 0 for coder turns
+cat > "${TMPDIR}/ZERO_SCOUT.md" << 'EOF'
+## Complexity Estimate
+Files to modify: 3
+Estimated lines of change: 50
+Interconnected systems: low
+Recommended coder turns: 0
+Recommended reviewer turns: 5
+Recommended tester turns: 10
+EOF
+
+if parse_scout_complexity "${TMPDIR}/ZERO_SCOUT.md" 2>/dev/null; then
+    echo "FAIL: 3.3 parse_scout_complexity should fail for 0 coder turns"
+    FAIL=1
+else
+    assert_eq "3.3 zero coder turns returns 1" "0" "0"
+fi
+
+# =============================================================================
+# Phase 4: apply_scout_turn_limits — applies clamped recommendations
+# =============================================================================
+
+cat > "${TMPDIR}/SCOUT_REPORT.md" << 'EOF'
+## Complexity Estimate
+Files to modify: 12
+Estimated lines of change: 800
+Interconnected systems: high
+Recommended coder turns: 80
+Recommended reviewer turns: 15
+Recommended tester turns: 50
+EOF
+
+DYNAMIC_TURNS_ENABLED=true
+apply_scout_turn_limits "${TMPDIR}/SCOUT_REPORT.md" 2>/dev/null
+
+assert_eq "4.1 coder turns applied" "80" "$ADJUSTED_CODER_TURNS"
+assert_eq "4.2 reviewer turns applied" "15" "$ADJUSTED_REVIEWER_TURNS"
+assert_eq "4.3 tester turns applied" "50" "$ADJUSTED_TESTER_TURNS"
+
+# 4.4: Recommendation below minimum
+cat > "${TMPDIR}/SCOUT_REPORT.md" << 'EOF'
+## Complexity Estimate
+Files to modify: 1
+Estimated lines of change: 10
+Interconnected systems: low
+Recommended coder turns: 5
+Recommended reviewer turns: 3
+Recommended tester turns: 4
+EOF
+
+apply_scout_turn_limits "${TMPDIR}/SCOUT_REPORT.md" 2>/dev/null
+
+assert_eq "4.4 coder clamped to min" "15" "$ADJUSTED_CODER_TURNS"
+assert_eq "4.5 reviewer clamped to min" "5" "$ADJUSTED_REVIEWER_TURNS"
+assert_eq "4.6 tester clamped to min" "10" "$ADJUSTED_TESTER_TURNS"
+
+# 4.7: Recommendation above maximum
+cat > "${TMPDIR}/SCOUT_REPORT.md" << 'EOF'
+## Complexity Estimate
+Files to modify: 50
+Estimated lines of change: 5000
+Interconnected systems: high
+Recommended coder turns: 500
+Recommended reviewer turns: 100
+Recommended tester turns: 300
+EOF
+
+apply_scout_turn_limits "${TMPDIR}/SCOUT_REPORT.md" 2>/dev/null
+
+assert_eq "4.7 coder clamped to max" "200" "$ADJUSTED_CODER_TURNS"
+assert_eq "4.8 reviewer clamped to max" "30" "$ADJUSTED_REVIEWER_TURNS"
+assert_eq "4.9 tester clamped to max" "100" "$ADJUSTED_TESTER_TURNS"
+
+# =============================================================================
+# Phase 5: apply_scout_turn_limits — disabled
+# =============================================================================
+
+DYNAMIC_TURNS_ENABLED=false
+apply_scout_turn_limits "${TMPDIR}/SCOUT_REPORT.md" 2>/dev/null
+
+assert_eq "5.1 disabled: coder uses default" "$CODER_MAX_TURNS" "$ADJUSTED_CODER_TURNS"
+assert_eq "5.2 disabled: reviewer uses default" "$REVIEWER_MAX_TURNS" "$ADJUSTED_REVIEWER_TURNS"
+assert_eq "5.3 disabled: tester uses default" "$TESTER_MAX_TURNS" "$ADJUSTED_TESTER_TURNS"
+
+DYNAMIC_TURNS_ENABLED=true
+
+# =============================================================================
+# Phase 6: estimate_post_coder_turns — heuristic from files/diff
+# =============================================================================
+
+# 6.1: Small change — few files, small diff
+SCOUT_REC_REVIEWER_TURNS=0  # Reset so estimate_post_coder_turns runs its heuristic
+
+cat > "${TMPDIR}/CODER_SUMMARY.md" << 'EOF'
+# Coder Summary
+## Status: COMPLETE
+## What Was Implemented
+Fixed the bug.
+## Files Modified
+- lib/foo.dart
+- lib/bar.dart
+EOF
+
+# Create a small diff
+echo "small change" >> "${TMPDIR}/init.txt"
+
+estimate_post_coder_turns 2>/dev/null
+
+# Should be the small-change estimate (reviewer ~8, tester ~20)
+assert_eq "6.1 small change reviewer" "8" "$ADJUSTED_REVIEWER_TURNS"
+assert_eq "6.2 small change tester" "20" "$ADJUSTED_TESTER_TURNS"
+
+# 6.3: When scout already set values, don't override
+SCOUT_REC_REVIEWER_TURNS=15
+estimate_post_coder_turns 2>/dev/null
+assert_eq "6.3 scout values preserved" "8" "$ADJUSTED_REVIEWER_TURNS"
+
+# Reset for future tests
+SCOUT_REC_REVIEWER_TURNS=0
+
+# =============================================================================
+# Phase 7: apply_scout_turn_limits — no scout report falls back to defaults
+# =============================================================================
+
+rm -f "${TMPDIR}/SCOUT_REPORT.md"
+apply_scout_turn_limits "${TMPDIR}/SCOUT_REPORT.md" 2>/dev/null
+
+assert_eq "7.1 no report: coder uses default" "$CODER_MAX_TURNS" "$ADJUSTED_CODER_TURNS"
+assert_eq "7.2 no report: reviewer uses default" "$REVIEWER_MAX_TURNS" "$ADJUSTED_REVIEWER_TURNS"
+assert_eq "7.3 no report: tester uses default" "$TESTER_MAX_TURNS" "$ADJUSTED_TESTER_TURNS"
+
+# =============================================================================
+# Done
+# =============================================================================
+
+if [ "$FAIL" -ne 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
lib/agent.sh: Added LAST_AGENT_TURNS, LAST_AGENT_EXIT_CODE, LAST_AGENT_ELAPSED, LAST_AGENT_NULL_RUN globals set after every run_agent() call. Null run flagged when turns ≤ threshold AND non-zero exit, or when 0 turns used. Added was_null_run() and check_agent_output() helpers. stages/coder.sh: Null run check after coder and scout. Coder null run saves state with null_run exit reason and actionable guidance. Scout null run warns and falls through. stages/review.sh: Reviewer null run retries on next cycle or exits at max cycles. stages/tester.sh: Tester null run saves state for resume. Threshold configurable via AGENT_NULL_RUN_THRESHOLD (default: 2). Dynamic Turn Limits
lib/turns.sh (new): clamp_turns(), parse_scout_complexity(), apply_scout_turn_limits(), estimate_post_coder_turns(). Parses ## Complexity Estimate from SCOUT_REPORT.md and sets ADJUSTED_CODER_TURNS, ADJUSTED_REVIEWER_TURNS, ADJUSTED_TESTER_TURNS clamped to configurable [MIN, MAX_CAP] bounds. prompts/scout.prompt.md: Extended with ## Complexity Estimate section and guidelines for files-to-modify, LOC, interconnected systems, and recommended turns per stage. stages/coder.sh: Scout now runs for all tasks when DYNAMIC_TURNS_ENABLED=true (not just BUG/FEAT). Parses complexity before archiving scout report. Architecture block passed to scout for smarter estimation. stages/review.sh: Calls estimate_post_coder_turns() before review loop. Uses ADJUSTED_REVIEWER_TURNS. stages/tester.sh: Uses ADJUSTED_TESTER_TURNS.
lib/config.sh: New defaults for DYNAMIC_TURNS_ENABLED, *_MIN_TURNS, *_MAX_TURNS_CAP. templates/pipeline.conf.example: Documented all new config keys.