### PR TITLE
ci(docs): prevent duplicate github-pages artifacts

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,14 +3,13 @@ name: Deploy Docs
 on:
   push:
     branches: [main]
-  release:
-    types: [published]
   workflow_dispatch:
 
 permissions:
   contents: read
   pages: write
   id-token: write
+  actions: write
 
 concurrency:
   group: "pages"
@@ -29,6 +28,13 @@ jobs:
           python-version: '3.x'
       - run: pip install -r docs/requirements.txt
       - run: mkdocs build
+      - name: Delete stale github-pages artifacts in this run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api -X GET "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
+            --jq '.artifacts[] | select(.name=="github-pages") | .id' \
+            | xargs -r -I {} gh api -X DELETE "/repos/${{ github.repository }}/actions/artifacts/{}"
       - uses: actions/upload-pages-artifact@v3
         with:
           path: site/


### PR DESCRIPTION
The Deploy Docs workflow was failing with 'Multiple artifacts named "github-pages" were unexpectedly found for this workflow run. Artifact count is 2.' Two compounding causes:

1. release:published overlapped with push:main. Publishing a release against a commit already on main fired two concurrent workflow runs competing to upload the same-named artifact.
2. Workflow re-runs can inherit stale artifacts from a previous attempt into the new attempt, leaving two github-pages artifacts in the same run_id.

Fix:
- Drop the release:published trigger (push:main + workflow_dispatch is sufficient; docs only deploy from main).
- Add a cleanup step that deletes any pre-existing github-pages artifacts in the current run before upload. Requires actions:write permission.